### PR TITLE
Upgrade to stable Flow and components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-component-base</artifactId>
-        <version>1.3.0.beta1</version>
+        <version>1.3.0</version>
         <relativePath />
     </parent>
 
@@ -24,14 +24,15 @@
     </organization>
 
     <properties>
-        <flow.version>1.3.0.beta1</flow.version>
+        <flow.version>1.3.0</flow.version>
         <testbench.version>6.0.1</testbench.version>
         <jetty.plugin.version>9.4.11.v20180605</jetty.plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <vaadin.details.version>1.0.0.beta1</vaadin.details.version>
+        <vaadin.details.flow.version>1.0.0.beta1</vaadin.details.flow.version>
+        <vaadin.details.wc.version>1.0.0</vaadin.details.wc.version>
     </properties>
 
     <modules>

--- a/vaadin-accordion-flow-integration-tests/pom.xml
+++ b/vaadin-accordion-flow-integration-tests/pom.xml
@@ -74,12 +74,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
-            <version>1.1.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-ordered-layout-flow</artifactId>
-            <version>1.1.0</version>
+            <version>1.3.0</version>
         </dependency>
 
         <dependency>

--- a/vaadin-accordion-flow-testbench/pom.xml
+++ b/vaadin-accordion-flow-testbench/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-details-testbench</artifactId>
-            <version>${vaadin.details.version}</version>
+            <version>${vaadin.details.flow.version}</version>
         </dependency>
     </dependencies>
 

--- a/vaadin-accordion-flow-vaadincom-demo/pom.xml
+++ b/vaadin-accordion-flow-vaadincom-demo/pom.xml
@@ -55,37 +55,37 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-checkbox-flow</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-date-picker-flow</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-form-layout-flow</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-notification-flow</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-progress-bar-flow</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-radio-button-flow</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-text-field-flow</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
     </dependencies>
 

--- a/vaadin-accordion-flow/pom.xml
+++ b/vaadin-accordion-flow/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-details-flow</artifactId>
-            <version>${vaadin.details.version}</version>
+            <version>${vaadin.details.flow.version}</version>
         </dependency>
 
 
@@ -56,6 +56,11 @@
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-accordion</artifactId>
             <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.vaadin</groupId>
+            <artifactId>vaadin-details</artifactId>
+            <version>${vaadin.details.wc.version}</version>
         </dependency>
 
 


### PR DESCRIPTION
- Upgrade Flow and flow-component-base to 1.3.0 final. 
- Upgrade test and demo component dependencies to the latest final.